### PR TITLE
単体テストの追加

### DIFF
--- a/Round_tombstone.py
+++ b/Round_tombstone.py
@@ -4,11 +4,12 @@ from mastodon import Mastodon
 import datetime as dt
 import pandas as pd
 
-#変数初期化
-mastodon = Mastodon(
-        client_id="clientcred.secret",
-        access_token="usercred.secret",
-        api_base_url = "https://gensokyo.cloud")
+if __name__ == "__main__":
+    #変数初期化
+    mastodon = Mastodon(
+            client_id="clientcred.secret",
+            access_token="usercred.secret",
+            api_base_url = "https://gensokyo.cloud")
 round_toots = pd.DataFrame({"username":[],"display_name":[],"created_at":[]})
 TIME29 = dt.time(17,29,0,0)
 TIME30 = dt.time(17,30,0,0)
@@ -86,86 +87,86 @@ def toot_number_rotated(participation, early_parti, multi_turn):
                 toot += "2度以上回した人は" + str(multi_turn) + "人です。"
     mastodon.toot(toot)
 
-
-#LTL
-#tootの取得
-toots = get_timeline(tl_type = "local")
-#データの整形
-round_toots = select_toots(toots = toots)
-
-#複数回回した人を数える
-for i in round_toots["username"].value_counts():
-    if i > 1:
-        multi_turn += 1
-
-#人数のダブりを削る
-round_toots = round_toots.drop_duplicates(["username"])
-round_toots = round_toots.reset_index(drop = True)
-
-#30分よりまえ、以降で回した人に分ける
-rotated_early = round_toots[round_toots.created_at < TIME30]
-rotated_just = round_toots[round_toots.created_at >= TIME30]
-rotated_just = rotated_just.reset_index(drop = True)
-participation = int(len(round_toots.index))    #参加者人数
-early_parti = int(len(rotated_early.index))
-
-#回転数についてtootする
-toot_number_rotated(participation = participation, early_parti = early_parti, multi_turn = multi_turn)
-
-#ランキング表記
-if participation > 0:
-    toot = ""
-    for i,rank in rotated_just.iterrows():
-        temp = str(int(str(i))+1) + "位：" + rank["display_name"] + " @" + rank["username"] + " [02" + str(rank["created_at"])[2:12] +"]\n"
-        if len(toot) + len(temp) >= 500:
-            mastodon.status_post(status = toot, visibility = "unlisted")
-            toot = ""
-        toot += temp
-    mastodon.status_post(status = toot, visibility = "unlisted")
-
-#早回し表記
-if early_parti > 0:
-    toot = "2時30分より前に回したtootです。\n"
-    for i,rank in rotated_early.iterrows():
-        temp = rank["display_name"] + " @" + rank["username"] + " [02" + str(rank["created_at"])[2:12] +"]\n"
-        if len(toot) + len(temp) >= 500:
-            mastodon.status_post(status = toot, visibility = "unlisted")
-            toot = "2時30分より前に回したtoot、続き。\n"
-        toot += temp
-    mastodon.status_post(status = toot, visibility = "unlisted")
-
-
-#HTL用
-round_toots = pd.DataFrame({"username":[],"display_name":[],"created_at":[]})
-toots = get_timeline(tl_type = "home")
-#round_toots = select_toots(toots = toots)
-
-"""
-取得したtootのリストから必要なtootを抜き出し、
-必要な要素のラベルで構成されたDataFrameに落とし込む
-"""
-for toot in toots:
-    time = dt.time(
-        int(toot["created_at"][11:13]), int(toot["created_at"][14:16]),
-        int(toot["created_at"][17:19]), int(toot["created_at"][20:23])*1000)
-    if TIME29 <= time and time <= TIME31:
-        if "public" != toot["visibility"]:
-            if "ｽﾞｽﾞｽﾞ" in toot["content"] or "ズズズ" in toot["content"] or "ずずず" in toot["content"]:
-                round_toots = round_toots.append(pd.DataFrame({
-                    "username":[toot["account"]["username"]],
-                    "display_name":[toot["account"]["display_name"]],
-                    "created_at":[time]}))
-
-
-#人数のダブりを削る
-round_toots = round_toots.drop_duplicates(["username"])
-round_toots = round_toots.reset_index(drop = True)
-participation = int(len(round_toots.index))    #参加者人数
-
-#時刻報告
-if participation > 0:
-    toot = ""
-    for i,rank in round_toots.iterrows():
-        toot = "@" + rank["username"] + " " + rank["display_name"] + " [02" + str(rank["created_at"])[2:12] +"]\n"
-        mastodon.status_post(status= toot, visibility = 'direct')
+if __name__ == "__main__":
+    #LTL
+    #tootの取得
+    toots = get_timeline(tl_type = "local")
+    #データの整形
+    round_toots = select_toots(toots = toots)
+    
+    #複数回回した人を数える
+    for i in round_toots["username"].value_counts():
+        if i > 1:
+            multi_turn += 1
+    
+    #人数のダブりを削る
+    round_toots = round_toots.drop_duplicates(["username"])
+    round_toots = round_toots.reset_index(drop = True)
+    
+    #30分よりまえ、以降で回した人に分ける
+    rotated_early = round_toots[round_toots.created_at < TIME30]
+    rotated_just = round_toots[round_toots.created_at >= TIME30]
+    rotated_just = rotated_just.reset_index(drop = True)
+    participation = int(len(round_toots.index))    #参加者人数
+    early_parti = int(len(rotated_early.index))
+    
+    #回転数についてtootする
+    toot_number_rotated(participation = participation, early_parti = early_parti, multi_turn = multi_turn)
+    
+    #ランキング表記
+    if participation > 0:
         toot = ""
+        for i,rank in rotated_just.iterrows():
+            temp = str(int(str(i))+1) + "位：" + rank["display_name"] + " @" + rank["username"] + " [02" + str(rank["created_at"])[2:12] +"]\n"
+            if len(toot) + len(temp) >= 500:
+                mastodon.status_post(status = toot, visibility = "unlisted")
+                toot = ""
+            toot += temp
+        mastodon.status_post(status = toot, visibility = "unlisted")
+    
+    #早回し表記
+    if early_parti > 0:
+        toot = "2時30分より前に回したtootです。\n"
+        for i,rank in rotated_early.iterrows():
+            temp = rank["display_name"] + " @" + rank["username"] + " [02" + str(rank["created_at"])[2:12] +"]\n"
+            if len(toot) + len(temp) >= 500:
+                mastodon.status_post(status = toot, visibility = "unlisted")
+                toot = "2時30分より前に回したtoot、続き。\n"
+            toot += temp
+        mastodon.status_post(status = toot, visibility = "unlisted")
+    
+    
+    #HTL用
+    round_toots = pd.DataFrame({"username":[],"display_name":[],"created_at":[]})
+    toots = get_timeline(tl_type = "home")
+    #round_toots = select_toots(toots = toots)
+    
+    """
+    取得したtootのリストから必要なtootを抜き出し、
+    必要な要素のラベルで構成されたDataFrameに落とし込む
+    """
+    for toot in toots:
+        time = dt.time(
+            int(toot["created_at"][11:13]), int(toot["created_at"][14:16]),
+            int(toot["created_at"][17:19]), int(toot["created_at"][20:23])*1000)
+        if TIME29 <= time and time <= TIME31:
+            if "public" != toot["visibility"]:
+                if "ｽﾞｽﾞｽﾞ" in toot["content"] or "ズズズ" in toot["content"] or "ずずず" in toot["content"]:
+                    round_toots = round_toots.append(pd.DataFrame({
+                        "username":[toot["account"]["username"]],
+                        "display_name":[toot["account"]["display_name"]],
+                        "created_at":[time]}))
+    
+    
+    #人数のダブりを削る
+    round_toots = round_toots.drop_duplicates(["username"])
+    round_toots = round_toots.reset_index(drop = True)
+    participation = int(len(round_toots.index))    #参加者人数
+    
+    #時刻報告
+    if participation > 0:
+        toot = ""
+        for i,rank in round_toots.iterrows():
+            toot = "@" + rank["username"] + " " + rank["display_name"] + " [02" + str(rank["created_at"])[2:12] +"]\n"
+            mastodon.status_post(status= toot, visibility = 'direct')
+            toot = ""

--- a/test_Round_tombstone.py
+++ b/test_Round_tombstone.py
@@ -20,19 +20,19 @@ class TestRoundTombstone(unittest.TestCase):
         rt.mastodon.timeline.side_effect = [
 # timeline取得 1回目
             [
-                { 'id': 10, 'created_at': '2017-11-04T17:29:00.000+00:00', 'content': 'ズズズ', 'account': { 'username': 'reimu', 'display_name': '霊夢', } },
-                { 'id': 11, 'created_at': '2017-11-04T17:30:00.000+00:00', 'content': 'ｽﾞｽﾞｽﾞ', 'account': { 'username': 'marisa', 'display_name': '魔理沙', } },
-                { 'id': 12, 'created_at': '2017-11-04T17:30:00.000+00:00', 'content': 'コスズ', 'account': { 'username': 'kosuzu', 'display_name': '小鈴', } },
+                { 'id': 10, 'created_at': '2017-11-04T17:29:00.000Z', 'content': 'ズズズ', 'account': { 'username': 'reimu', 'display_name': '霊夢', } },
+                { 'id': 11, 'created_at': '2017-11-04T17:30:00.000Z', 'content': 'ｽﾞｽﾞｽﾞ', 'account': { 'username': 'marisa', 'display_name': '魔理沙', } },
+                { 'id': 12, 'created_at': '2017-11-04T17:30:00.000Z', 'content': 'コスズ', 'account': { 'username': 'kosuzu', 'display_name': '小鈴', } },
             ],
 # timeline取得 2回目
             [
-                { 'id': 8, 'created_at': '2017-11-04T17:29:00.000+00:00', 'content': 'ズズズ', 'account': { 'username': 'sakuya', 'display_name': '咲夜', } },
-                { 'id': 9, 'created_at': '2017-11-04T17:29:00.000+00:00', 'content': 'ズズズ', 'account': { 'username': 'sanae', 'display_name': '早苗', } },
+                { 'id': 8, 'created_at': '2017-11-04T17:29:00.000Z', 'content': 'ズズズ', 'account': { 'username': 'sakuya', 'display_name': '咲夜', } },
+                { 'id': 9, 'created_at': '2017-11-04T17:29:00.000Z', 'content': 'ズズズ', 'account': { 'username': 'sanae', 'display_name': '早苗', } },
             ],
 # timeline取得 3回目。実際には呼ばれない
 # BUG: 29:00.000を含めるかどうかがget_timelineとselect_tootsで一致していない
             [
-                { 'id': 7, 'created_at': '2017-11-04T17:29:00.000+00:00', 'content': 'ズズズ', 'account': { 'username': 'akyu', 'display_name': '阿求', } },
+                { 'id': 7, 'created_at': '2017-11-04T17:29:00.000Z', 'content': 'ズズズ', 'account': { 'username': 'akyu', 'display_name': '阿求', } },
             ],
         ]
         results = rt.get_timeline('local')
@@ -44,10 +44,10 @@ class TestRoundTombstone(unittest.TestCase):
     def test_select_toots(self):
         toots = [
 # positive
-            { 'id': 10, 'created_at': '2017-11-04T17:29:00.000+00:00', 'content': 'ズズズ', 'account': { 'username': 'reimu', 'display_name': '霊夢', } },
-            { 'id': 11, 'created_at': '2017-11-04T17:30:00.000+00:00', 'content': 'ｽﾞｽﾞｽﾞ', 'account': { 'username': 'marisa', 'display_name': '魔理沙', } },
+            { 'id': 10, 'created_at': '2017-11-04T17:29:00.000Z', 'content': 'ズズズ', 'account': { 'username': 'reimu', 'display_name': '霊夢', } },
+            { 'id': 11, 'created_at': '2017-11-04T17:30:00.000Z', 'content': 'ｽﾞｽﾞｽﾞ', 'account': { 'username': 'marisa', 'display_name': '魔理沙', } },
 # negative
-            { 'id': 12, 'created_at': '2017-11-04T17:30:00.000+00:00', 'content': 'コスズ', 'account': { 'username': 'kosuzu', 'display_name': '小鈴', } },
+            { 'id': 12, 'created_at': '2017-11-04T17:30:00.000Z', 'content': 'コスズ', 'account': { 'username': 'kosuzu', 'display_name': '小鈴', } },
         ]
         results = rt.select_toots(toots)
         self.assertEqual(['reimu','marisa'], list(results['username']))

--- a/test_Round_tombstone.py
+++ b/test_Round_tombstone.py
@@ -54,33 +54,33 @@ class TestRoundTombstone(unittest.TestCase):
         self.assertEqual(['霊夢','魔理沙'], list(results['display_name']))
 
 # toot_number_rotatedについて、細かいケースごとにテスト
-    def test_toot_number_rotated_no_partitian(self):
+    def test_toot_number_rotated_no_participation(self):
         rt.toot_number_rotated(0, 0, 0)
         rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石は回転しませんでした。')
 
-    def test_toot_number_rotated_1_partitian(self):
+    def test_toot_number_rotated_1_participation(self):
         rt.toot_number_rotated(1, 0, 0)
 # BUG: 4人未満の場合に余計な0が付く
         rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石の回転は1人による04分の1回転でした。')
 
-    def test_toot_number_rotated_2_partitians(self):
+    def test_toot_number_rotated_2_participations(self):
         rt.toot_number_rotated(2, 0, 0)
 # BUG: 4人未満の場合に余計な0が付く
         rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石の回転は2人による02分の1回転でした。')
 
-    def test_toot_number_rotated_4_partitians(self):
+    def test_toot_number_rotated_4_participations(self):
         rt.toot_number_rotated(4, 0, 0)
         rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石の回転は4人による1回転でした。')
 
-    def test_toot_number_rotated_5_partitians(self):
+    def test_toot_number_rotated_5_participations(self):
         rt.toot_number_rotated(5, 0, 0)
         rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石の回転は5人による1と4分の1回転でした。')
 
-    def test_toot_number_rotated_6_partitians(self):
+    def test_toot_number_rotated_6_participations(self):
         rt.toot_number_rotated(6, 0, 0)
         rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石の回転は6人による1と2分の1回転でした。')
 
-    def test_toot_number_rotated_early_partitian(self):
+    def test_toot_number_rotated_early_participation(self):
         rt.toot_number_rotated(6, 1, 0)
         rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石の回転は6人による1と2分の1回転でした。\nまた、2時30分になる前に回した人は1人です。')
 
@@ -88,7 +88,7 @@ class TestRoundTombstone(unittest.TestCase):
         rt.toot_number_rotated(6, 0, 1)
         rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石の回転は6人による1と2分の1回転でした。2度以上回した人は1人です。')
 
-    def test_toot_number_rotated_early_partition_and_multi_turn(self):
+    def test_toot_number_rotated_early_participation_and_multi_turn(self):
         rt.toot_number_rotated(6, 1, 1)
         rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石の回転は6人による1と2分の1回転でした。\nまた、2時30分になる前に回した人は1人、2度以上回した人は1人です。')
 

--- a/test_Round_tombstone.py
+++ b/test_Round_tombstone.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+import unittest
+from unittest.mock import Mock
+import Round_tombstone as rt
+from datetime import date
+import mastodon
+
+TODAY_STR = '{dt.month}月{dt.day}日'.format(dt = date.today())
+
+class TestRoundTombstone(unittest.TestCase):
+    def setUp(self):
+# rt.mastodon をmockするので、元のが定義されていたら退避
+        self.original_mastodon = rt.mastodon if hasattr(rt, 'mastodon') else None
+        rt.mastodon = Mock(spec=mastodon.Mastodon)
+
+    def tearDown(self):
+        rt.mastodon = self.original_mastodon
+
+    def test_get_timeline(self):
+        rt.mastodon.timeline.side_effect = [
+# timeline取得 1回目
+            [
+                { 'id': 10, 'created_at': '2017-11-04T17:29:00.000+00:00', 'content': 'ズズズ', 'account': { 'username': 'reimu', 'display_name': '霊夢', } },
+                { 'id': 11, 'created_at': '2017-11-04T17:30:00.000+00:00', 'content': 'ｽﾞｽﾞｽﾞ', 'account': { 'username': 'marisa', 'display_name': '魔理沙', } },
+                { 'id': 12, 'created_at': '2017-11-04T17:30:00.000+00:00', 'content': 'コスズ', 'account': { 'username': 'kosuzu', 'display_name': '小鈴', } },
+            ],
+# timeline取得 2回目
+            [
+                { 'id': 8, 'created_at': '2017-11-04T17:29:00.000+00:00', 'content': 'ズズズ', 'account': { 'username': 'sakuya', 'display_name': '咲夜', } },
+                { 'id': 9, 'created_at': '2017-11-04T17:29:00.000+00:00', 'content': 'ズズズ', 'account': { 'username': 'sanae', 'display_name': '早苗', } },
+            ],
+# timeline取得 3回目。実際には呼ばれない
+# BUG: 29:00.000を含めるかどうかがget_timelineとselect_tootsで一致していない
+            [
+                { 'id': 7, 'created_at': '2017-11-04T17:29:00.000+00:00', 'content': 'ズズズ', 'account': { 'username': 'akyu', 'display_name': '阿求', } },
+            ],
+        ]
+        results = rt.get_timeline('local')
+# 取得したTLの検証。
+        self.assertEqual(['咲夜', '早苗', '霊夢', '魔理沙', '小鈴'], [x['account']['display_name'] for x in results])
+# mastodon APIの呼び出し回数検証
+        self.assertEqual(2, len(rt.mastodon.timeline.mock_calls))
+
+    def test_select_toots(self):
+        toots = [
+# positive
+            { 'id': 10, 'created_at': '2017-11-04T17:29:00.000+00:00', 'content': 'ズズズ', 'account': { 'username': 'reimu', 'display_name': '霊夢', } },
+            { 'id': 11, 'created_at': '2017-11-04T17:30:00.000+00:00', 'content': 'ｽﾞｽﾞｽﾞ', 'account': { 'username': 'marisa', 'display_name': '魔理沙', } },
+# negative
+            { 'id': 12, 'created_at': '2017-11-04T17:30:00.000+00:00', 'content': 'コスズ', 'account': { 'username': 'kosuzu', 'display_name': '小鈴', } },
+        ]
+        results = rt.select_toots(toots)
+        self.assertEqual(['reimu','marisa'], list(results['username']))
+        self.assertEqual(['霊夢','魔理沙'], list(results['display_name']))
+
+# toot_number_rotatedについて、細かいケースごとにテスト
+    def test_toot_number_rotated_no_partitian(self):
+        rt.toot_number_rotated(0, 0, 0)
+        rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石は回転しませんでした。')
+
+    def test_toot_number_rotated_1_partitian(self):
+        rt.toot_number_rotated(1, 0, 0)
+# BUG: 4人未満の場合に余計な0が付く
+        rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石の回転は1人による04分の1回転でした。')
+
+    def test_toot_number_rotated_2_partitians(self):
+        rt.toot_number_rotated(2, 0, 0)
+# BUG: 4人未満の場合に余計な0が付く
+        rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石の回転は2人による02分の1回転でした。')
+
+    def test_toot_number_rotated_4_partitians(self):
+        rt.toot_number_rotated(4, 0, 0)
+        rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石の回転は4人による1回転でした。')
+
+    def test_toot_number_rotated_5_partitians(self):
+        rt.toot_number_rotated(5, 0, 0)
+        rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石の回転は5人による1と4分の1回転でした。')
+
+    def test_toot_number_rotated_6_partitians(self):
+        rt.toot_number_rotated(6, 0, 0)
+        rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石の回転は6人による1と2分の1回転でした。')
+
+    def test_toot_number_rotated_early_partitian(self):
+        rt.toot_number_rotated(6, 1, 0)
+        rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石の回転は6人による1と2分の1回転でした。\nまた、2時30分になる前に回した人は1人です。')
+
+    def test_toot_number_rotated_multi_turn(self):
+        rt.toot_number_rotated(6, 0, 1)
+        rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石の回転は6人による1と2分の1回転でした。2度以上回した人は1人です。')
+
+    def test_toot_number_rotated_early_partition_and_multi_turn(self):
+        rt.toot_number_rotated(6, 1, 1)
+        rt.mastodon.toot.assert_called_once_with(TODAY_STR + 'の墓石の回転は6人による1と2分の1回転でした。\nまた、2時30分になる前に回した人は1人、2度以上回した人は1人です。')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`Round_tombstone.py`で定義されている各関数について単体テストを追加しました。

現行の仕様をテストコードに落とし込む（仕様化テスト）方針でテストを記述しています。
テストを追加することで、以下のことができるようになることを目的にしています。
 * 仕様が維持されていることを確かめながらリファクタリングする
 * 現行の仕様のバグを修正していく

## テストの実行について
以下のコマンドで実行できます。
```bash
$ python test_Round_tombstone.py
...........
----------------------------------------------------------------------
Ran 11 tests in 0.015s

OK
$
```

pipで[coverageパッケージ](https://coverage.readthedocs.io/en/coverage-4.4.2/)を入れれば下記の方法でテストカバレッジもとれます。
```bash
$ coverage run test_Round_tombstone.py
$ coverage html
# htmlcov/ 以下にカバレッジレポートのhtmlが生成される
```
----

@Kelvin27315 ご確認よろしくお願いします 🙏 